### PR TITLE
Add GDPR-compliant privacy policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ We welcome contributions from the community! Whether it's bug reports, feature r
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
+## Privacy 🚦
+
+The project is GDPR compliant. The application does not collect, store or share any personal data. A dedicated [Privacy Policy](/privacy) page is available when running the site.
+
 ## Contact 📧
 
 - **Project Lead**: Louis Paulet - [louispaulet13@gmail.com](mailto:louispaulet13@gmail.com)

--- a/alt_index.html
+++ b/alt_index.html
@@ -75,7 +75,8 @@
     </div>
     <footer class="footer mt-auto py-3 bg-light">
         <div class="container">
-            <span class="text-muted">Generative Website &copy; 2023</span>
+            <span class="text-muted">Generative Website &copy; 2023</span> |
+            <a href="/privacy">Privacy Policy</a>
         </div>
     </footer>
     <script>

--- a/app.py
+++ b/app.py
@@ -49,6 +49,10 @@ def index():
 def alt_index():
     return render_template_string(open('alt_index.html').read())
 
+@app.route('/privacy')
+def privacy():
+    return render_template_string(open('privacy.html').read())
+
 @app.route('/generate', methods=['GET'])
 def generate_page():
     link_text = request.args.get('link_text', 'Default')

--- a/index.html
+++ b/index.html
@@ -58,7 +58,8 @@
     </div>
     <footer class="footer mt-auto py-3 bg-light">
         <div class="container">
-            <span class="text-muted">Generative Website &copy; 2023</span>
+            <span class="text-muted">Generative Website &copy; 2023</span> |
+            <a href="/privacy">Privacy Policy</a>
         </div>
     </footer>
     <script>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet">
+    <title>Privacy Policy</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+        }
+
+        .content {
+            flex-grow: 1;
+        }
+
+        .footer {
+            background-color: #f8f9fa;
+            padding: 15px 0;
+            text-align: center;
+            position: relative;
+        }
+    </style>
+</head>
+<body>
+    <nav class="navbar navbar-light bg-light">
+        <a class="navbar-brand" href="/">Generative Website</a>
+    </nav>
+    <div class="container mt-4 content">
+        <h1>Privacy Policy</h1>
+        <p>We respect your privacy and comply fully with the General Data Protection Regulation (GDPR). This website does not collect, store or share any personal data.</p>
+        <p>Your interactions with the site remain entirely on your device. No analytics, tracking cookies or personal information are retained by us.</p>
+    </div>
+    <footer class="footer mt-auto py-3 bg-light">
+        <div class="container">
+            <span class="text-muted">Generative Website &copy; 2023</span> |
+            <a href="/privacy">Privacy Policy</a>
+        </div>
+    </footer>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add privacy.html with GDPR compliance note
- link to privacy policy from footer
- route `/privacy` in Flask app
- document privacy policy in README

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684c956c2cb483209ff9b4123654b0e3