### PR TITLE
Add dynamic page generator component

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,8 +38,8 @@ def extract_html_from_string(html_string):
 with open('api_key.txt', 'r') as file:
     openai_api_key = file.read().strip()
 
-# Initialize ChatOpenAI object with the loaded API key
-chat_model = ChatOpenAI(openai_api_key=openai_api_key)
+# Default ChatOpenAI object with the key from disk.
+default_chat_model = ChatOpenAI(openai_api_key=openai_api_key)
 
 @app.route('/')
 def index():
@@ -53,9 +53,17 @@ def alt_index():
 def generate_page():
     link_text = request.args.get('link_text', 'Default')
     
+    # Use API key from header if provided, otherwise fallback to default
+    incoming_key = request.headers.get("X-API-Key", "").strip()
+    chat_model = (
+        ChatOpenAI(openai_api_key=incoming_key)
+        if incoming_key
+        else default_chat_model
+    )
+
     # Create a HumanMessage object with the link_text
     messages = [HumanMessage(content=link_text)]
-    
+
     # Generate response using ChatOpenAI
     response = chat_model.predict_messages(messages)
     

--- a/vite-react-tailwind/package-lock.json
+++ b/vite-react-tailwind/package-lock.json
@@ -12,7 +12,8 @@
         "openai": "^5.3.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.2"
+        "react-router-dom": "^7.6.2",
+        "zod": "^3.25.64"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -4466,6 +4467,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.64",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.64.tgz",
+      "integrity": "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/vite-react-tailwind/package-lock.json
+++ b/vite-react-tailwind/package-lock.json
@@ -8,6 +8,8 @@
       "name": "vite-react-tailwind",
       "version": "0.0.0",
       "dependencies": {
+        "js-cookie": "^3.0.5",
+        "openai": "^5.3.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2"
@@ -2677,6 +2679,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3219,6 +3230,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.3.0.tgz",
+      "integrity": "sha512-VIKmoF7y4oJCDOwP/oHXGzM69+x0dpGFmN9QmYO+uPbLFOmmnwO+x1GbsgUtI+6oraxomGZ566Y421oYVu191w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/vite-react-tailwind/package.json
+++ b/vite-react-tailwind/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "js-cookie": "^3.0.5",
+    "openai": "^5.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2"

--- a/vite-react-tailwind/package.json
+++ b/vite-react-tailwind/package.json
@@ -14,7 +14,8 @@
     "openai": "^5.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.2"
+    "react-router-dom": "^7.6.2",
+    "zod": "^3.25.64"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/vite-react-tailwind/src/components/ApiKeySetup.jsx
+++ b/vite-react-tailwind/src/components/ApiKeySetup.jsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import Cookies from "js-cookie";
+
+const COOKIE_NAME = "openai_api_key";
+
+export default function ApiKeySetup({ className = "" }) {
+  const [apiKey, setApiKey] = useState("");
+  const [saved, setSaved] = useState(false);
+
+  // Load the key from cookies on first mount
+  useEffect(() => {
+    const existingKey = Cookies.get(COOKIE_NAME) || "";
+    if (existingKey) {
+      setApiKey(existingKey);
+      setSaved(true);
+    }
+  }, []);
+
+  const saveKey = () => {
+    if (!apiKey) return;
+    // Persist the key for 30 days
+    Cookies.set(COOKIE_NAME, apiKey, { expires: 30 });
+    setSaved(true);
+  };
+
+  const resetKey = () => {
+    Cookies.remove(COOKIE_NAME);
+    setApiKey("");
+    setSaved(false);
+  };
+
+  return (
+    <div
+      className={`w-full max-w-xl mx-auto bg-gray-50 border border-gray-200 p-6 rounded-lg shadow ${className}`}
+    >
+      {!saved ? (
+        <>
+          <h3 className="text-xl font-semibold mb-2">
+            Enter your OpenAI API key
+          </h3>
+          <p className="text-sm text-gray-600 mb-4">
+            Your key will be stored locally in a cookie so you don’t have to
+            re-enter it. It never leaves your browser.
+          </p>
+          <input
+            type="password"
+            className="w-full border p-2 rounded mb-4"
+            placeholder="sk-..."
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value.trim())}
+          />
+          <button
+            onClick={saveKey}
+            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition"
+            disabled={!apiKey}
+          >
+            Save API Key
+          </button>
+        </>
+      ) : (
+        <>
+          <h3 className="text-xl font-semibold mb-2">
+            API Key saved (
+            {apiKey ? `${apiKey.slice(0, 8)}…` : ""}
+            )
+          </h3>
+          <p className="text-sm text-gray-600 mb-4">
+            You can now generate pages using your OpenAI account.
+          </p>
+          <button
+            onClick={resetKey}
+            className="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 transition"
+          >
+            Remove / Change API Key
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/vite-react-tailwind/src/components/PageGenerator.jsx
+++ b/vite-react-tailwind/src/components/PageGenerator.jsx
@@ -77,12 +77,16 @@ export default function PageGenerator() {
         </button>
       </div>
       {content && (
-        <iframe
-          title="generated-content"
-          className="mt-6 border rounded w-1/2 mx-auto"
-          style={{ height: "50vh" }}
-          srcDoc={content}
-        />
+        <div
+          className="crt mx-auto mt-6"
+          style={{ width: "50vw", aspectRatio: "4 / 3" }}
+        >
+          <iframe
+            title="generated-content"
+            className="w-full h-full rounded-none"
+            srcDoc={content}
+          />
+        </div>
       )}
     </div>
   );

--- a/vite-react-tailwind/src/components/PageGenerator.jsx
+++ b/vite-react-tailwind/src/components/PageGenerator.jsx
@@ -77,9 +77,11 @@ export default function PageGenerator() {
         </button>
       </div>
       {content && (
-        <div
-          className="mt-6 border rounded p-4"
-          dangerouslySetInnerHTML={{ __html: content }}
+        <iframe
+          title="generated-content"
+          className="mt-6 border rounded w-1/2 mx-auto"
+          style={{ height: "50vh" }}
+          srcDoc={content}
         />
       )}
     </div>

--- a/vite-react-tailwind/src/components/PageGenerator.jsx
+++ b/vite-react-tailwind/src/components/PageGenerator.jsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+
+export default function PageGenerator() {
+  const [prompt, setPrompt] = useState("");
+  const [content, setContent] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleGenerate = async () => {
+    if (!prompt.trim()) return;
+    setLoading(true);
+    try {
+      const resp = await fetch(`/generate?link_text=${encodeURIComponent(prompt)}`);
+      const text = await resp.text();
+      setContent(text);
+    } catch {
+      setContent("<p class='text-red-500'>Failed to generate page.</p>");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="mt-8">
+      <div className="flex gap-2">
+        <input
+          type="text"
+          className="flex-grow border rounded px-3 py-2"
+          placeholder="Enter a prompt"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+        />
+        <button
+          onClick={handleGenerate}
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+          disabled={loading}
+        >
+          {loading ? "Generating..." : "Generate"}
+        </button>
+      </div>
+      {content && (
+        <div
+          className="mt-6 border rounded p-4"
+          dangerouslySetInnerHTML={{ __html: content }}
+        />
+      )}
+    </div>
+  );
+}

--- a/vite-react-tailwind/src/components/PageGenerator.jsx
+++ b/vite-react-tailwind/src/components/PageGenerator.jsx
@@ -1,4 +1,6 @@
 import { useState } from "react";
+import Cookies from "js-cookie";
+import getOpenAIClient from "../openaiClient";
 
 export default function PageGenerator() {
   const [prompt, setPrompt] = useState("");
@@ -9,9 +11,38 @@ export default function PageGenerator() {
     if (!prompt.trim()) return;
     setLoading(true);
     try {
-      const resp = await fetch(`/generate?link_text=${encodeURIComponent(prompt)}`);
-      const text = await resp.text();
-      setContent(text);
+      const apiKey = Cookies.get("openai_api_key") || "";
+      // If user provided an API key, call OpenAI directly to avoid extra round-trip
+      if (apiKey) {
+        const openai = getOpenAIClient();
+        try {
+          const completion = await openai.chat.completions.create({
+            model: "gpt-4.1-nano-2025-04-14",
+            messages: [
+              {
+                role: "user",
+                content: `You are a browser. You have the knowledge of the whole compressed internet in yourself. You only answer in raw HTML that will be directly displayed. 
+Take the following user request, or url, and display the requested URL page.  
+### USER REQUEST
+${prompt}`,
+              },
+            ],
+          });
+          setContent(completion.choices?.[0]?.message?.content || "");
+        } catch (err) {
+          console.error(err);
+          setContent(
+            "<p class='text-red-500'>OpenAI request failed. Please try again.</p>"
+          );
+        }
+      } else {
+        // Fallback to server-side generation (uses default key)
+        const resp = await fetch(
+          `/generate?link_text=${encodeURIComponent(prompt)}`
+        );
+        const text = await resp.text();
+        setContent(text);
+      }
     } catch {
       setContent("<p class='text-red-500'>Failed to generate page.</p>");
     } finally {

--- a/vite-react-tailwind/src/index.css
+++ b/vite-react-tailwind/src/index.css
@@ -1,3 +1,38 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  /* CRT monitor look */
+  .crt {
+    @apply border-8 border-gray-700 rounded-lg shadow-lg;
+    position: relative;
+  }
+  .crt::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    /* green scan-lines */
+    background-image: repeating-linear-gradient(
+      0deg,
+      rgba(0, 255, 0, 0.05) 0px,
+      rgba(0, 255, 0, 0.05) 2px,
+      transparent 2px,
+      transparent 4px
+    );
+  }
+  .crt::before {
+    /* subtle curvature glare */
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(
+      ellipse at center,
+      rgba(255, 255, 255, 0.15) 0%,
+      rgba(0, 0, 0, 0) 70%
+    );
+    mix-blend-mode: overlay;
+  }
+}

--- a/vite-react-tailwind/src/openaiClient.js
+++ b/vite-react-tailwind/src/openaiClient.js
@@ -1,0 +1,17 @@
+import OpenAI from "openai";
+import Cookies from "js-cookie";
+
+/**
+ * Returns an OpenAI client configured with the API key stored in cookies.
+ * If the key is missing, it returns null so callers can handle that case.
+ */
+export default function getOpenAIClient() {
+  const apiKey = Cookies.get("openai_api_key");
+  if (!apiKey) return null;
+
+  return new OpenAI({
+    apiKey,
+    // Explicitly opt-in to running the OpenAI SDK in the browser.
+    dangerouslyAllowBrowser: true,
+  });
+}

--- a/vite-react-tailwind/src/pages/About.jsx
+++ b/vite-react-tailwind/src/pages/About.jsx
@@ -2,10 +2,18 @@ export default function About() {
   return (
     <section className="max-w-5xl mx-auto px-4 py-12">
       <h2 className="text-3xl font-bold mb-4">About Us</h2>
-      <p className="text-gray-700">
-        This project showcases a simple React + Vite app styled with Tailwind
-        CSS. Feel free to explore and customize it to fit your needs.
+      <p className="text-gray-700 mb-4">
+        Generative Website is an innovative project that leverages OpenAI's
+        ChatGPT to dynamically create HTML pages. Built with Vite, React and
+        Tailwind CSS, it demonstrates how AI can craft complete web pages from a
+        single prompt.
       </p>
+      <ul className="list-disc list-inside text-gray-700 space-y-1">
+        <li>Dynamic page generation based on your prompts</li>
+        <li>OpenAI ChatGPT integration</li>
+        <li>Modern interface styled with Tailwind</li>
+        <li>Dockerized for easy setup</li>
+      </ul>
     </section>
   );
 }

--- a/vite-react-tailwind/src/pages/Home.jsx
+++ b/vite-react-tailwind/src/pages/Home.jsx
@@ -1,10 +1,15 @@
+import PageGenerator from "../components/PageGenerator";
+
 export default function Home() {
   return (
     <section className="max-w-5xl mx-auto px-4 py-12 text-center">
-      <h2 className="text-3xl font-bold mb-4">Welcome to MySite</h2>
-      <p className="text-gray-700">
-        This is the homepage. Use the navbar to navigate through the site.
+      <h2 className="text-3xl font-bold mb-4">Welcome to Generative Website</h2>
+      <p className="text-gray-700 mb-4">
+        Generative Website leverages OpenAI's ChatGPT to dynamically create HTML
+        pages based on your prompts. Use the generator below to craft a new page
+        on the fly.
       </p>
+      <PageGenerator />
     </section>
   );
 }

--- a/vite-react-tailwind/src/pages/Home.jsx
+++ b/vite-react-tailwind/src/pages/Home.jsx
@@ -1,3 +1,4 @@
+import ApiKeySetup from "../components/ApiKeySetup";
 import PageGenerator from "../components/PageGenerator";
 
 export default function Home() {
@@ -9,6 +10,7 @@ export default function Home() {
         pages based on your prompts. Use the generator below to craft a new page
         on the fly.
       </p>
+      <ApiKeySetup className="mb-8" />
       <PageGenerator />
     </section>
   );


### PR DESCRIPTION
## Summary
- add `PageGenerator` component for generating HTML pages via the backend
- update Home page to describe the project and include the generator
- update About page with project details from README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c965acf648320abb7cd2ca0467915