### PR TITLE
Improve Windows 95 styling

### DIFF
--- a/vite-react-tailwind/src/components/Footer.jsx
+++ b/vite-react-tailwind/src/components/Footer.jsx
@@ -1,6 +1,6 @@
 export default function Footer() {
   return (
-    <footer className="bg-gray-100 py-4 mt-12">
+    <footer className="win95-window py-4 mt-12">
       <div className="max-w-5xl mx-auto px-4 text-center text-gray-500 text-sm">
         © {new Date().getFullYear()} MySite. All rights reserved.
       </div>

--- a/vite-react-tailwind/src/components/Navbar.jsx
+++ b/vite-react-tailwind/src/components/Navbar.jsx
@@ -7,7 +7,7 @@ export default function Navbar() {
   const inactive = "text-gray-700 hover:text-blue-600";
 
   return (
-    <nav className="bg-white shadow mb-6">
+    <nav className="win95-window mb-6">
       <div className="max-w-5xl mx-auto px-4">
         <div className="flex items-center justify-between h-16">
           <h1 className="text-xl font-bold text-blue-600">MySite</h1>

--- a/vite-react-tailwind/src/components/PageGenerator.jsx
+++ b/vite-react-tailwind/src/components/PageGenerator.jsx
@@ -60,7 +60,7 @@ const handleGenerate = async () => {
   };
 
   return (
-    <div className="mt-8">
+    <div className="mx-auto mt-8 space-y-2" style={{ width: "50vw" }}>
       <div className="win95-toolbar">
         <input
           type="text"
@@ -86,24 +86,18 @@ if (e.key === "Enter" && !loading) {
       </div>
       {content && (
         <>
-        <div
-          className="mx-auto mt-6"
-          style={{ width: "50vw", aspectRatio: "4 / 3" }}
-        >
-          <iframe
-            title="generated-content"
-            className="w-full h-full rounded-none"
-            srcDoc={content}
-          />
-        </div>
-        <div
-          className="win95-taskbar mx-auto"
-          style={{ width: "50vw" }}
-        >
-          <span className="win95-start">Start</span>
-          <span className="flex-grow" />
-          <span className="win95-clock">12:00 AM</span>
-        </div>
+          <div className="crt w-full" style={{ aspectRatio: "4 / 3" }}>
+            <iframe
+              title="generated-content"
+              className="w-full h-full rounded-none"
+              srcDoc={content}
+            />
+          </div>
+          <div className="win95-taskbar w-full">
+            <span className="win95-start">Start</span>
+            <span className="flex-grow" />
+            <span className="win95-clock">12:00 AM</span>
+          </div>
         </>
       )}
     </div>

--- a/vite-react-tailwind/src/index.css
+++ b/vite-react-tailwind/src/index.css
@@ -3,11 +3,17 @@
 @tailwind utilities;
 
 @layer components {
+  body {
+    background: var(--win-bg);
+    font-family: "MS Sans Serif", Arial, sans-serif;
+    color: #000;
+  }
+
   /* CRT monitor look */
   .crt {
     @apply border-8 border-gray-700 rounded-lg shadow-lg;
     position: relative;
-}
+  }
 
 /* ───── Windows 95 / Netscape-era styling ───── */
 :root{
@@ -55,10 +61,17 @@
   border-bottom-color:var(--win-dark);
   border-right-color:var(--win-dark);
 }
-.win95-clock{@apply px-2;}
+  .win95-clock{@apply px-2;}
 
-/* Remove old CRT border when reused elsewhere */
-.crt{border:none!important;}
+  .win95-window {
+    background: var(--win-bg);
+    border: 2px solid var(--win-light);
+    border-bottom-color: var(--win-dark);
+    border-right-color: var(--win-dark);
+    padding: 0.5rem;
+  }
+
+/* CRT overlay effects */
   .crt::after {
     content: "";
     position: absolute;

--- a/vite-react-tailwind/src/pages/About.jsx
+++ b/vite-react-tailwind/src/pages/About.jsx
@@ -1,6 +1,6 @@
 export default function About() {
   return (
-    <section className="max-w-5xl mx-auto px-4 py-12">
+    <section className="win95-window max-w-5xl mx-auto px-4 py-12">
       <h2 className="text-3xl font-bold mb-4">About Us</h2>
       <p className="text-gray-700 mb-4">
         Generative Website is an innovative project that leverages OpenAI's

--- a/vite-react-tailwind/src/pages/Home.jsx
+++ b/vite-react-tailwind/src/pages/Home.jsx
@@ -3,7 +3,7 @@ import PageGenerator from "../components/PageGenerator";
 
 export default function Home() {
   return (
-    <section className="max-w-5xl mx-auto px-4 py-12 text-center">
+    <section className="win95-window max-w-5xl mx-auto px-4 py-12 text-center">
       <h2 className="text-3xl font-bold mb-4">Welcome to Generative Website</h2>
       <p className="text-gray-700 mb-4">
         Generative Website leverages OpenAI's ChatGPT to dynamically create HTML

--- a/vite-react-tailwind/src/pages/Tos.jsx
+++ b/vite-react-tailwind/src/pages/Tos.jsx
@@ -1,6 +1,6 @@
 export default function Tos() {
   return (
-    <section className="max-w-5xl mx-auto px-4 py-12">
+    <section className="win95-window max-w-5xl mx-auto px-4 py-12">
       <h2 className="text-3xl font-bold mb-4">Terms of Service</h2>
       <p className="text-gray-700 mb-2">
         By using this site, you agree to the following terms and conditions.


### PR DESCRIPTION
## Summary
- make global background and fonts mimic Win95
- style navbar and footer using `win95-window`
- ensure CRT elements share width and add CRT overlay effects
- wrap pages in Win95-styled container

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684caddd8abc83208479cb37808b3537