### PR TITLE
Add min height to CRT display

### DIFF
--- a/generative_website_react/src/components/PageGenerator.jsx
+++ b/generative_website_react/src/components/PageGenerator.jsx
@@ -86,7 +86,10 @@ if (e.key === "Enter" && !loading) {
       </div>
       {content && (
         <>
-          <div className="crt w-full" style={{ aspectRatio: "4 / 3" }}>
+          <div
+            className="crt w-full"
+            style={{ aspectRatio: "4 / 3", minHeight: "600px" }}
+          >
             <iframe
               title="generated-content"
               className="w-full h-full rounded-none"


### PR DESCRIPTION
## Summary
- keep CRT container at least 600px tall in React interface

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684cb0c860408320b28f437460bbc949