### PR TITLE
Improve navbar Win95 styling

### DIFF
--- a/generative_website_react/src/components/Navbar.jsx
+++ b/generative_website_react/src/components/Navbar.jsx
@@ -1,16 +1,19 @@
-import { NavLink } from "react-router-dom";
+import { NavLink, Link } from "react-router-dom";
 
 export default function Navbar() {
-  const base =
-    "px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200";
-  const active = "text-white bg-blue-600";
-  const inactive = "text-gray-700 hover:text-blue-600";
+  const base = "win95-button text-sm";
+  const active = "bg-blue-600 text-white";
+  const inactive = "hover:bg-blue-100 text-gray-800";
 
   return (
-    <nav className="win95-window mb-6">
+    <nav className="win95-navbar mb-6">
       <div className="max-w-5xl mx-auto px-4">
         <div className="flex items-center justify-between h-16">
-          <h1 className="text-xl font-bold text-blue-600">MySite</h1>
+          <h1 className="text-xl font-bold text-blue-600">
+            <Link to="/" className="hover:underline">
+              MySite
+            </Link>
+          </h1>
           <div className="space-x-2">
             <NavLink
               to="/"

--- a/generative_website_react/src/components/Navbar.jsx
+++ b/generative_website_react/src/components/Navbar.jsx
@@ -11,7 +11,7 @@ export default function Navbar() {
         <div className="flex items-center justify-between h-16">
           <h1 className="text-xl font-bold text-blue-600">
             <Link to="/" className="hover:underline">
-              MySite
+              GenWeb
             </Link>
           </h1>
           <div className="space-x-2">

--- a/generative_website_react/src/index.css
+++ b/generative_website_react/src/index.css
@@ -63,13 +63,21 @@
 }
   .win95-clock{@apply px-2;}
 
-  .win95-window {
+.win95-window {
     background: var(--win-bg);
     border: 2px solid var(--win-light);
     border-bottom-color: var(--win-dark);
     border-right-color: var(--win-dark);
     padding: 0.5rem;
-  }
+}
+
+.win95-navbar {
+  background: var(--win-bg);
+  border: 2px solid var(--win-light);
+  border-bottom-color: var(--win-dark);
+  border-right-color: var(--win-dark);
+  padding: 0.25rem 0.5rem;
+}
 
 /* CRT overlay effects */
   .crt::after {


### PR DESCRIPTION
## Summary
- make the logo clickable to return home
- style nav links with Win95 look and add a Win95 themed navbar class

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684cb088615083208b49f0a97ed3f885