### PR TITLE
Fix footer icon to match navbar

### DIFF
--- a/generative_website_react/src/components/Footer.jsx
+++ b/generative_website_react/src/components/Footer.jsx
@@ -2,7 +2,7 @@ export default function Footer() {
   return (
     <footer className="win95-window py-4 mt-12">
       <div className="max-w-5xl mx-auto px-4 text-center text-gray-500 text-sm">
-        © {new Date().getFullYear()} <span role="img" aria-label="logo">🌐</span> GenWeb. All rights reserved.
+        © {new Date().getFullYear()} <img src="/retro_browser_logo.webp" alt="logo" className="inline w-4 h-4 align-text-bottom" /> GenWeb. All rights reserved.
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary
- update footer icon in React site to use the same `retro_browser_logo.webp` used in the navbar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cc786cc948320b80be51a80c6476d