### PR TITLE
Add root license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 the_french_artist
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ The `generative_website_react` folder is a standard Vite + React project with th
 - **Routing** (`src/App.jsx`): `/`, `/about` and `/tos` routes are defined using React Router with a 404 fallback.
 - **Libraries**: React 19, React Router DOM 7, Tailwind CSS 3, OpenAI SDK, js-cookie for persistence and zod for schema validation.
 - **Configuration**: Vite handles bundling (`vite.config.js`) and Tailwind (`tailwind.config.js`), with deployment via the `gh-pages` script.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- add MIT LICENSE at repo root
- reference the license in README

## Testing
- `npm install` in generative_website_react
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684da5b2f9208320a3684a61ac669335