### PR TITLE
Add confetti when clicking OK

### DIFF
--- a/generative_website_react/package-lock.json
+++ b/generative_website_react/package-lock.json
@@ -8,6 +8,7 @@
       "name": "generative_website_react",
       "version": "0.0.0",
       "dependencies": {
+        "canvas-confetti": "^1.9.3",
         "dompurify": "^3.2.6",
         "js-cookie": "^3.0.5",
         "openai": "^5.3.0",
@@ -1802,6 +1803,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/generative_website_react/package.json
+++ b/generative_website_react/package.json
@@ -12,6 +12,7 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
+    "canvas-confetti": "^1.9.3",
     "dompurify": "^3.2.6",
     "js-cookie": "^3.0.5",
     "openai": "^5.3.0",

--- a/generative_website_react/src/pages/About.jsx
+++ b/generative_website_react/src/pages/About.jsx
@@ -1,3 +1,5 @@
+import confetti from "canvas-confetti";
+
 export default function About() {
   // Re-use the same retro Win95 icons as the new TOS page
   const floppyIcon =
@@ -73,7 +75,9 @@ export default function About() {
 
       {/* OK button */}
       <div className="text-right mt-6">
-        <button className="win95-button px-6">OK</button>
+        <button className="win95-button px-6" onClick={() => confetti({ particleCount: 80, spread: 70 })}>
+          OK
+        </button>
       </div>
     </section>
   );

--- a/generative_website_react/src/pages/Tos.jsx
+++ b/generative_website_react/src/pages/Tos.jsx
@@ -1,3 +1,5 @@
+import confetti from "canvas-confetti";
+
 export default function Tos() {
   const floppyIcon =
     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAB8ElEQVRYhdWXsYrbQBRFjxbDdhJ4qywi9eLWnStXAZX5FTcCfcCAv2DbDaTIH/gLLLzFdi42uLAJwTCGFWi6LYLTeJyRNGOt1xOF3OYh6WnunTvvaTQBgBBiTw3ZzU391kUQLy/V8bMsAOilabqfTCas1+tKwubuzquAz8/PADw+PrHd/gDYA8GVTpBSIqVktVohpWR4uO8r6nHruDIvlFKEYYhSyiv5ECrjOgXopDAMvQvI85zlcqnttwswHRgCT4eXfUSALMvIsuzfOKCRpillWR6vey4HvuMXt7cfeXj4ClBZhooA04FPr69eBXwD+v2QoqgWotOBL9fXXgV8sJA3BPxVBwp1ngNLzw7YyKGlC3T7+IjFwYE6TnaBz2/B9r9z4Nf9fSP5EvTj+LwuiOPYuYGcQmFUuyuacO4FXZA3BNTJdS34IrfVgBcH3kp+Vg2YcT6fv9kJE0mSsNn8PCnC2QUmeRRFrWTmFqvJB4MBSqnLHDBR/5kQQjgFjcdjdrtd6zK0OlCfoRCCsixJkoQ8z4/PoihquAD47wJNZkKT25bKexfYZtqpA1qETVQnDsCfejBn/F4HzuoCgNFoVCE1RdlEaFIbOUAviiIWi8Wxol2YTqekacpsNnPm2ByoH0TqecEhNk7HHSBoT+kAvwFQQf99MahzHwAAAABJRU5ErkJggg==";
@@ -57,7 +59,9 @@ export default function Tos() {
         </p>
       </div>
       <div className="text-right mt-6">
-        <button className="win95-button px-6">OK</button>
+        <button className="win95-button px-6" onClick={() => confetti({ particleCount: 80, spread: 70 })}>
+          OK
+        </button>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add `canvas-confetti` dependency
- trigger confetti on OK buttons in About and TOS pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684db0da3e888320a35646f5e5cbbddb